### PR TITLE
Uninstall legacy theme

### DIFF
--- a/config/sync/responsive_image.styles.full_width_image.yml
+++ b/config/sync/responsive_image.styles.full_width_image.yml
@@ -6,34 +6,34 @@ dependencies:
     - image.style.large
     - image.style.medium
   theme:
-    - personal_blog
+    - personal
 id: full_width_image
 label: 'Full width image'
 image_style_mappings:
   -
     image_mapping_type: image_style
     image_mapping: large
-    breakpoint_id: personal_blog.extra_large
+    breakpoint_id: personal.extra_large
     multiplier: 1x
   -
     image_mapping_type: image_style
     image_mapping: large
-    breakpoint_id: personal_blog.large
+    breakpoint_id: personal.large
     multiplier: 1x
   -
     image_mapping_type: image_style
     image_mapping: large
-    breakpoint_id: personal_blog.medium
+    breakpoint_id: personal.medium
     multiplier: 1x
   -
     image_mapping_type: image_style
     image_mapping: medium
-    breakpoint_id: personal_blog.small
+    breakpoint_id: personal.small
     multiplier: 1x
   -
     image_mapping_type: image_style
     image_mapping: medium
-    breakpoint_id: personal_blog.extra_small
+    breakpoint_id: personal.extra_small
     multiplier: 1x
-breakpoint_group: personal_blog
+breakpoint_group: personal
 fallback_image_style: medium


### PR DESCRIPTION
The `personal_blog` theme has not been used in a while now but due to spaghetti dependencies it hasn't been deactivated until now. Now is the time.